### PR TITLE
Add license info to the gemspec.

### DIFF
--- a/camertron-eprun.gemspec
+++ b/camertron-eprun.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.authors  = ["Ayumu Nojima (野島 歩)", "Martin J. Dürst", "Cameron Dutro"]
   s.email    = ["duerst@it.aoyama.ac.jp"]
   s.homepage = "http://github.com/camertron/camertron-eprun"
+  s.license  = "Ruby"
 
   s.description = s.summary = "Efficient pure Ruby Unicode normalization."
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.